### PR TITLE
Install a specific version of ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl ansible py-pip py-requests && \
-  pip install -U pip
+RUN apk add --no-cache bash git curl py-pip py-requests python2-dev libffi-dev libressl-dev build-base && \
+  pip install -U pip ansible==2.6.3 && \
+  apk del python2-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/
 ENTRYPOINT ["/bin/drone-ansible"]


### PR DESCRIPTION
We should be in control which version of ansible gets installed. The current base image comes only with Ansible 2.4 while we are already at Ansible 2.6 with lots of new features. Now we can define when to change the ansible version :bomb: