### PR TITLE
install boto3 and botocore from alpine apk

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -6,6 +6,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests python3-dev libffi-dev libressl-dev libressl build-base && \
+  apk add --no-cache py3-boto3 py3-botocore --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
   pip3 install -U pip && \
   pip3 install ansible==2.8.4 && \
   apk del python3-dev libffi-dev libressl-dev build-base


### PR DESCRIPTION
Hi, this is another attempt to add boto libraries for ansible.
As asked in https://github.com/drone-plugins/drone-ansible/pull/26 I used alpine's APK repo to install botocore and boto3 (yes, ansible want both of them installed).

I've tested the image myself and it seems to be working. 
Please let me know if there's anything else.