### PR TITLE
Add paramiko

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 boto3==1.10.6 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 boto3==1.10.6 && \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 && boto3==1.10.6 \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && boto3==1.10.6 \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 boto3==1.10.6 && \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 paramiko==2.6.0 && \
+  pip3 install ansible==2.8.4 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -5,9 +5,9 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko py3-boto3@testing python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.8.4 && \
+  pip3 install ansible==2.8.4 boto3==1.10.6 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm64/drone-ansible /bin/


### PR DESCRIPTION
ansible with network_cli needs paramiko for ssh connections to network devices.
paramiko needs gcc (and build-base) installed.

so adding paramiko to a requirements.txt is not working. And since ansible uses paramiko for ssh for multiple modules I thought we should include it in the official plugin.