### PR TITLE
update ansible to v2.10.0

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.9.13 boto3==1.13.10 && \
+  pip3 install ansible==2.10.0 boto3==1.13.10 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/amd64/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.9.13 boto3==1.13.10 && \
+  pip3 install ansible==2.10.0 boto3==1.13.10 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm/drone-ansible /bin/

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -7,7 +7,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
   pip3 install -U pip && \
-  pip3 install ansible==2.9.13 boto3==1.13.10 && \
+  pip3 install ansible==2.10.0 boto3==1.13.10 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base
 
 ADD release/linux/arm64/drone-ansible /bin/


### PR DESCRIPTION
This PR will update Ansible to v2.10 and is using the Ansible
distribution package which still contains a pre-set of collections to
keep backward-compatibility as much as possible.

As a lot has changed in Ansible v2.10 I would suggest ta create a v3.x
tag.

