### PR TITLE
Change Galaxy flag to -r to support both collections and roles

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -225,7 +225,7 @@ func (p *Plugin) galaxyCommand() *exec.Cmd {
 	args := []string{
 		"install",
 		"--force",
-		"--role-file",
+		"-r",
 		p.Config.Galaxy,
 	}
 


### PR DESCRIPTION
Changed Galaxy flag from --role-file to -r so you may use it to install collections as well. 

https://docs.ansible.com/ansible/latest/user_guide/collections_using.html