### PR TITLE
Add a no-galaxy-force option

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,10 +69,10 @@ func main() {
 			Usage:  "prepend paths to module library",
 			EnvVar: "PLUGIN_MODULE_PATH",
 		},
-		cli.BoolFlag{
-			Name:   "no-galaxy-force",
-			Usage:  "don't force overwriting an existing role or collection",
-			EnvVar: "PLUGIN_NO_GALAXY_FORCE",
+		cli.BoolTFlag{
+			Name:   "galaxy-force",
+			Usage:  "force overwriting an existing role or collection",
+			EnvVar: "PLUGIN_GALAXY_FORCE",
 		},
 		cli.BoolFlag{
 			Name:   "check",
@@ -210,7 +210,7 @@ func run(c *cli.Context) error {
 			Tags:          c.String("tags"),
 			ExtraVars:     c.StringSlice("extra-vars"),
 			ModulePath:    c.StringSlice("module-path"),
-			NoGalaxyForce: c.Bool("no-galaxy-force"),
+			GalaxyForce:   c.Bool("galaxy-force"),
 			Check:         c.Bool("check"),
 			Diff:          c.Bool("diff"),
 			FlushCache:    c.Bool("flush-cache"),

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 		cli.BoolFlag{
 			Name:   "no-galaxy-force",
 			Usage:  "don't force overwriting an existing role or collection",
-			EnvVar: "NO_GALAXY_FORCE",
+			EnvVar: "PLUGIN_NO_GALAXY_FORCE",
 		},
 		cli.BoolFlag{
 			Name:   "check",

--- a/main.go
+++ b/main.go
@@ -70,6 +70,11 @@ func main() {
 			EnvVar: "PLUGIN_MODULE_PATH",
 		},
 		cli.BoolFlag{
+			Name:   "no-galaxy-force",
+			Usage:  "don't force overwriting an existing role or collection",
+			EnvVar: "NO_GALAXY_FORCE",
+		},
+		cli.BoolFlag{
 			Name:   "check",
 			Usage:  "run a check, do not apply any changes",
 			EnvVar: "PLUGIN_CHECK",
@@ -205,6 +210,7 @@ func run(c *cli.Context) error {
 			Tags:          c.String("tags"),
 			ExtraVars:     c.StringSlice("extra-vars"),
 			ModulePath:    c.StringSlice("module-path"),
+			NoGalaxyForce: c.Bool("no-galaxy-force"),
 			Check:         c.Bool("check"),
 			Diff:          c.Bool("diff"),
 			FlushCache:    c.Bool("flush-cache"),

--- a/plugin.go
+++ b/plugin.go
@@ -32,6 +32,7 @@ type (
 		Tags              string
 		ExtraVars         []string
 		ModulePath        []string
+		NoGalaxyForce     bool
 		Check             bool
 		Diff              bool
 		FlushCache        bool
@@ -224,10 +225,16 @@ func (p *Plugin) requirementsCommand() *exec.Cmd {
 func (p *Plugin) galaxyCommand() *exec.Cmd {
 	args := []string{
 		"install",
-		"--force",
+	}
+
+	if p.Config.NoGalaxyForce == false {
+		args = append(args, "--force")
+	}
+
+	args = append(args,
 		"--role-file",
 		p.Config.Galaxy,
-	}
+	)
 
 	if p.Config.Verbose > 0 {
 		args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", p.Config.Verbose)))
@@ -248,7 +255,7 @@ func (p *Plugin) ansibleCommand(inventory string) *exec.Cmd {
 	if len(p.Config.ModulePath) > 0 {
 		args = append(args, "--module-path", strings.Join(p.Config.ModulePath, ":"))
 	}
-	
+
 	if p.Config.VaultID != "" {
 		args = append(args, "--vault-id", p.Config.VaultID)
 	}
@@ -256,11 +263,11 @@ func (p *Plugin) ansibleCommand(inventory string) *exec.Cmd {
 	if p.Config.VaultPasswordFile != "" {
 		args = append(args, "--vault-password-file", p.Config.VaultPasswordFile)
 	}
-	
+
 	for _, v := range p.Config.ExtraVars {
 		args = append(args, "--extra-vars", v)
 	}
-	
+
 	if p.Config.ListHosts {
 		args = append(args, "--list-hosts")
 		args = append(args, p.Config.Playbooks...)

--- a/plugin.go
+++ b/plugin.go
@@ -227,7 +227,7 @@ func (p *Plugin) galaxyCommand() *exec.Cmd {
 		"install",
 	}
 
-	if p.Config.GalaxyForce == true {
+	if p.Config.GalaxyForce {
 		args = append(args, "--force")
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -32,7 +32,7 @@ type (
 		Tags              string
 		ExtraVars         []string
 		ModulePath        []string
-		NoGalaxyForce     bool
+		GalaxyForce       bool
 		Check             bool
 		Diff              bool
 		FlushCache        bool
@@ -227,7 +227,7 @@ func (p *Plugin) galaxyCommand() *exec.Cmd {
 		"install",
 	}
 
-	if p.Config.NoGalaxyForce == false {
+	if p.Config.GalaxyForce == true {
 		args = append(args, "--force")
 	}
 


### PR DESCRIPTION
Related to #43.
This add the possibility to remove the `--force` tag during galaxy install. The end goal is to allow caching of galaxy packages.