### PR TITLE
replace libressl-dev libressl with openssl-dev

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -5,7 +5,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base && \
+RUN apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev openssl-dev build-base && \
   pip3 install -U pip && \
   pip3 install ansible==2.10.0 boto3==1.13.10 && \
   apk del --no-cache python3-dev libffi-dev libressl-dev build-base


### PR DESCRIPTION
when building a docker image ,the error as follow:
```
The command '/bin/sh -c apk del libressl-dev;apk add --no-cache bash git curl rsync openssh-client sshpass py3-pip py3-requests py3-paramiko python3-dev libffi-dev libressl-dev libressl build-base &&   pip3 install -U pip &&   pip3 install ansible==2.10.0 boto3==1.13.10 &&   apk del --no-cache python3-dev libffi-dev libressl-dev build-base' returned a non-zero code: 1
```
i found the detail error message by run apk fix
```
ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20 owned by libretls-3.3.3-r0.
ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20.0.3 owned by libretls-3.3.3-r0.
1 error; 353 MiB in 108 packages
```
Note that in this case, we could replace`libressl-dev  libessl` with openssl-dev and everything would probably just work. 